### PR TITLE
Feature/home page template changes

### DIFF
--- a/src/JNCC.PublicWebsite.Core/Models/AboutUsPage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/AboutUsPage.generated.cs
@@ -159,14 +159,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/ArticlePage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/ArticlePage.generated.cs
@@ -153,14 +153,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/BizDevServicePage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/BizDevServicePage.generated.cs
@@ -159,14 +159,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/GenericListingPage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/GenericListingPage.generated.cs
@@ -159,14 +159,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/HomePage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/HomePage.generated.cs
@@ -121,6 +121,14 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual decimal NumberOfTweets => this.Value<decimal>(_publishedValueFallback, "numberOfTweets");
 
 		///<summary>
+		/// Preamble
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("preamble")]
+		public virtual global::Umbraco.Cms.Core.Strings.IHtmlEncodedString Preamble => this.Value<global::Umbraco.Cms.Core.Strings.IHtmlEncodedString>(_publishedValueFallback, "preamble");
+
+		///<summary>
 		/// Fallback Image: This is used by related items that do not have an image associated with them .
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/IndividualJobPage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/IndividualJobPage.generated.cs
@@ -222,14 +222,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/InternalTextPage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/InternalTextPage.generated.cs
@@ -151,14 +151,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/RelatedItemsComposition.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/RelatedItemsComposition.generated.cs
@@ -27,11 +27,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems { get; }
 
-		/// <summary>Search Query</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		string RelatedItemsSearchQuery { get; }
-
 		/// <summary>Show Related Items</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
 		bool ShowRelatedItems { get; }
@@ -80,19 +75,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
 		[return: global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		public static global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> GetRelatedItems(IRelatedItemsComposition that, IPublishedValueFallback publishedValueFallback) => that.Value<global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent>>(publishedValueFallback, "relatedItems");
-
-		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		/// <summary>Static getter for Search Query</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[return: global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		public static string GetRelatedItemsSearchQuery(IRelatedItemsComposition that, IPublishedValueFallback publishedValueFallback) => that.Value<string>(publishedValueFallback, "relatedItemsSearchQuery");
 
 		///<summary>
 		/// Show Related Items

--- a/src/JNCC.PublicWebsite.Core/Models/ScienceAtoZpage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/ScienceAtoZpage.generated.cs
@@ -144,14 +144,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/ScienceCategoryPage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/ScienceCategoryPage.generated.cs
@@ -183,14 +183,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite.Core/Models/ScienceDetailsPage.generated.cs
+++ b/src/JNCC.PublicWebsite.Core/Models/ScienceDetailsPage.generated.cs
@@ -182,14 +182,6 @@ namespace JNCC.PublicWebsite.Core.Models
 		public virtual global::System.Collections.Generic.IEnumerable<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent> RelatedItems => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItems(this, _publishedValueFallback);
 
 		///<summary>
-		/// Search Query: A search term used to find related items. If no term is used the page headline or name will be used instead.
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("relatedItemsSearchQuery")]
-		public virtual string RelatedItemsSearchQuery => global::JNCC.PublicWebsite.Core.Models.RelatedItemsComposition.GetRelatedItemsSearchQuery(this, _publishedValueFallback);
-
-		///<summary>
 		/// Show Related Items
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "9.2.0+763cb70e677ac0c85557b19b5df09eccfa1b9dfb")]

--- a/src/JNCC.PublicWebsite/Views/HomePage.cshtml
+++ b/src/JNCC.PublicWebsite/Views/HomePage.cshtml
@@ -4,7 +4,12 @@
     Layout = "Master.cshtml";
 }
 <main id="main" class="home-a landing-page">
-    @(await Component.InvokeAsync("Carousel", new { model = Model }))
+	@(await Component.InvokeAsync("Carousel", new { model = Model }))
+	<div class="container">
+		<div class="row">
+			@Html.Raw(Model.Preamble)
+		</div>
+	</div>
     @(await Component.InvokeAsync("CalloutCards", new { model = Model }))
     @(await Component.InvokeAsync("Resources", new { model = Model }))
     @(await Component.InvokeAsync("LatestNewsAndSocialFeed", new { model = Model }))

--- a/src/JNCC.PublicWebsite/Views/Partials/CalloutCards.cshtml
+++ b/src/JNCC.PublicWebsite/Views/Partials/CalloutCards.cshtml
@@ -16,12 +16,12 @@
                                 </div>
                             }
                             <div class="card-section">
-                                <h2>@card.Title</h2>
+	                            <h2><a href="@card.ReadMoreButton.Url">@card.Title</a></h2>
                                 @Html.Raw(card.Content)
-                                @if (card.ReadMoreButton != null)
+                              @*  @if (card.ReadMoreButton != null)
                                 {
                                     <a href="@card.ReadMoreButton.Url" class="button expanded">@card.ReadMoreButton.Text</a>
-                                }
+                                }*@
                             </div>
                         </article>
                     </div>

--- a/src/JNCC.PublicWebsite/Views/Partials/LatestNewsAndSocialFeed.cshtml
+++ b/src/JNCC.PublicWebsite/Views/Partials/LatestNewsAndSocialFeed.cshtml
@@ -15,7 +15,7 @@
             @if (Model.LatestNews.Any())
             {
                 <div class="columns small-12 large-8">
-                    <h2>Latest News</h2>
+	                <h2><a href="/news/">Latest News</a></h2>
                     <div class="news-holder">
                         @foreach (var newsItem in Model.LatestNews)
                         {
@@ -43,7 +43,7 @@
             @if (Model.SocialFeed != null && Model.SocialFeed.HasTwitterFeedUrl)
             {
                 <div class="columns small-12 large-4 twitter-print-hide">
-                    <h2>Twitter</h2>
+                    <h2><a href="https://twitter.com/JNCC_UK" target="_blank">Twitter</a></h2>
                     <div class="twitter-widget">
                         <article class="card full-border">
                             <div class="card-section">

--- a/src/JNCC.PublicWebsite/wwwroot/css/app.css
+++ b/src/JNCC.PublicWebsite/wwwroot/css/app.css
@@ -8764,7 +8764,7 @@ button.slick-arrow {
 }
 
 .search-form {
-    background-color: #eeebeb;
+	background-color: #faf9f9;
 	position: absolute;
 	top: 100%;
 	left: 0;

--- a/src/JNCC.PublicWebsite/wwwroot/css/app.css
+++ b/src/JNCC.PublicWebsite/wwwroot/css/app.css
@@ -4901,6 +4901,7 @@ overflow: hidden;
 	padding: 1rem;
 }
 
+
 .card-section > :last-child {
 	margin-bottom: 0;
 }
@@ -7968,6 +7969,7 @@ a:hover > .label {
 
 .card {
 	height: calc(100% - .9375rem);
+    position: relative;
 }
 
 .card .img-holder {
@@ -7979,13 +7981,33 @@ a:hover > .label {
 
 .card .card-section {
 	padding-bottom: 1.375rem;
+    
 }
 
-.card .card-section p {
-	-webkit-box-flex: 1;
-	-ms-flex-positive: 1;
-	flex-grow: 1;
-}
+	.card .card-section h2, .card .card-section h2 a {
+        color: #666262;
+        text-decoration: none !important;
+	}
+
+		.card .card-section h2 a:after {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
+		}
+
+		.card .card-section h2 a:hover {
+			color: #2d7a29;
+			text-decoration: none !important;
+		}
+
+		.card .card-section p {
+			-webkit-box-flex: 1;
+			-ms-flex-positive: 1;
+			flex-grow: 1;
+		}
 
 .card .footer-list {
 	display: -webkit-box;
@@ -14115,7 +14137,7 @@ img.float-right,
 	}
 
 	.articles-section {
-		padding: 6.25rem 0 5.1875rem;
+		padding: 6.25rem 0 2rem;
 	}
 
 	.articles-section .row {
@@ -14163,7 +14185,7 @@ img.float-right,
 	}
 
 	.widget-section {
-		padding: 9.1875rem 0 8.3125rem;
+		padding: 3rem 0 3rem;
 	}
 
 	.widget-section .decor {

--- a/src/JNCC.PublicWebsite/wwwroot/css/app.css
+++ b/src/JNCC.PublicWebsite/wwwroot/css/app.css
@@ -8764,7 +8764,7 @@ button.slick-arrow {
 }
 
 .search-form {
-	background-color: #faf9f9;
+    background-color: #eeebeb;
 	position: absolute;
 	top: 100%;
 	left: 0;

--- a/src/JNCC.PublicWebsite/wwwroot/js/app.js
+++ b/src/JNCC.PublicWebsite/wwwroot/js/app.js
@@ -78,15 +78,25 @@ function initFoundation() {
 	});
 }
 
+
 // slick init
 function initSlickCarousel() {
+
+    var total = $('.main-slider .slider-image').length, // get the number of slides
+        rand = Math.floor(Math.random() * total); // random number
+
 	jQuery('.main-slider').slick({
-		slidesToScroll: 1,
-		rows: 0,
+        slidesToScroll: 1,
+        initialSlide: rand,
+        rows: 0,
+        autoplay: true,
+        autoplaySpeed: 5000,
+        speed: 2000,
+        arrows: false,
 		centerMode: true,
 		centerPadding: '0px',
 		adaptiveHeight: true
-	});
+    });
 }
 
 function initScienceDetailsSlickCarousel() {


### PR DESCRIPTION
- Adjust search panel colour contrast
- Remove the clickable hero image carousel and replace with a randomly generated (from a set selection) hero image.
- The option to add some copy should be available below the hero image and above the block content.
- In place of structured blocks with clickable links, our preference would be to have wholly clickable cards containing headings, copy and images
- Reduce the white space between the cards and the latest news section, as well as removing the JNCC logo from the page background.
- Adjust the image processing in the ‘latest news’ boxes. At the moment, the images that are pulled through can be stretched or distorted by the image ratios. These tiles should also be styled as cards.
- Add a link in the ‘Twitter’ <h2> and the Latest News <h2>, directing to JNCC’s Twitter page and the website’s news section.