### PR TITLE
Install CSP Manager and remove old web-based CSP

### DIFF
--- a/src/JNCC.PublicWebsite/JNCC.PublicWebsite.csproj
+++ b/src/JNCC.PublicWebsite/JNCC.PublicWebsite.csproj
@@ -22,6 +22,7 @@
 	<!-- Force windows to use ICU. Otherwise Windows 10 2019H1+ will do it, but older windows 10 and most if not all winodws servers will run NLS -->
 	<ItemGroup>
 		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+		<PackageReference Include="Umbraco.Community.CSPManager" Version="1.4.2" />
 		<PackageReference Include="Umbraco.Deploy.OnPrem" Version="13.4.3" />
 		<PackageReference Include="Umbraco.Forms" Version="13.9.6" />
 		<PackageReference Include="Umbraco.StorageProviders.AzureBlob" Version="13.1.0" />

--- a/src/JNCC.PublicWebsite/web.config
+++ b/src/JNCC.PublicWebsite/web.config
@@ -12,16 +12,6 @@
 			<httpProtocol>
 				<customHeaders>
 					<remove name="X-Powered-By" />
-					<add name="Content-Security-Policy-Report-Only" value="default-src 'self';
-						 base-uri 'none';
-						 img-src 'self' *.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com region1.analytics.google.com www.google.co.uk https://img.youtube.com https://i.ytimg.com;
-						 script-src 'self' www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com region1.analytics.google.com www.google.co.uk www.gstatic.com *.ytimg.com www.youtube.com www.youtube-nocookie.com cdnjs.cloudflare.com *.aspnetcdn.com *.civiccomputing.com *.azure.com 'sha256-cFDK7zS/LnRy9jW0Rgec+b8qX8vt7+S5Mvb0bcNktHQ=' 'sha256-8I9lYH3RZwaYQVTy5WkRtQqk9GGGTfdInCMAeUt6U9Q=' 'sha256-G98Ynwi2gQAL7+NptQ9lUatzGKCyPfV4i5g0jpVsClU=';
-						 style-src 'self' www.gstatic.com *.fontawesome.com *.googleapis.com 'nonce-k2svo49hkrmbs5s3g4t4awmg';
-						 font-src 'self' *.fontawesome.com *.googleapis.com *.gstatic.com;
-						 connect-src 'self' *.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com region1.analytics.google.com www.google.co.uk *.civiccomputing.com *.googleapis.com *.azure.com;
-						 object-src 'none';
-						 frame-src 'self' *.gov.uk www.youtube.com www.youtube-nocookie.com;
-						 frame-ancestors 'self' *.gov.uk;" />
 					<add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
 					<add name="Permissions-Policy" value="interest-cohort=()" />
 


### PR DESCRIPTION
Installs the Umbraco CSP manager to allow us to make CSP updates without a deploy.